### PR TITLE
specify assembly & update s2s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,7 @@
 __pycache__/
 **/.snakemake/
 **/ananse/
-example/outdir
+anansenake.egg-info/
+build/
+example/outdir/
+example/tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 .idea/
 .ipynb_checkpoints/
 __pycache__/
+**/log.txt
 **/.snakemake/
 **/ananse/
 anansenake.egg-info/
 build/
+example/config.yaml
 example/outdir/
 example/tmp/

--- a/envs/ananse.yaml
+++ b/envs/ananse.yaml
@@ -10,7 +10,7 @@ dependencies:
   - adjusttext
   - dask
   - genomepy >=0.11.0
-  - gimmemotifs >=0.17.0
+  - gimmemotifs-minimal =0.17.1
   - loguru
   - matplotlib >=2
   - networkx
@@ -25,12 +25,11 @@ dependencies:
   - scikit-learn
   - scipy >=0.9.0
   - seaborn
-  - sklearn-contrib-lightning
   - tqdm
   # ananse dev
   - pip
   - pip:
-    - git+https://github.com/vanheeringen-lab/ANANSE.git@develop
+    - git+https://github.com/vanheeringen-lab/ANANSE.git@b1c0e2a647be2302c2f02c98e9bbe8dfcb79f038
 
   # eventually, this should be the only requirement:
-  # - ananse>0.3.0
+  # - ananse =0.4.0

--- a/envs/gimme.yaml
+++ b/envs/gimme.yaml
@@ -4,6 +4,6 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - gimmemotifs >=0.17.0
+  - gimmemotifs-minimal =0.17.1
   - gffread
   - orthofinder

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -1,6 +1,6 @@
 # example commands:
 # snakemake --configfile example/config.yaml --dry-run
-# snakemake --configfile example/config.yaml --use-conda --conda-frontend mamba --resources mem_mb=40_000 -j 28 > log.txt 2>&1
+# snakemake --configfile example/config.yaml --use-conda --conda-frontend mamba --resources mem_mb=10_000 -j 14 > example/log.txt 2>&1
 
 # input
 rna_samples: example/rna_samples.tsv

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -34,8 +34,10 @@ database: gimme.vertebrate.v5.0  # options: https://gimmemotifs.readthedocs.io/e
 tmp_dir: example/tmp  # intermediate output location, can be None
 keep_tmp_data: true  # keep the orthofinder output (in the tmp_dir)?
 
-# use descriptive names in the sample.tsv
-use_descriptive_names: false  # true for seq2science > 0.7.1
+# seq2science options
+use_descriptive_names: true  # used descriptive names from the sample.tsv as counts table columns
+merged_technical_reps: true  # set to false if you used 'technical_replicates: "keep" in s2s'
+merged_biological_reps: true  # set to false if you used 'biological_replicates: "keep" in s2s'
 
 # ANANSE binding
 jaccard: 0.2  # default: 0.1

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - seq2science=0.7.0
+  - seq2science>=0.9.2

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - seq2science>=0.9.2
+  - seq2science =0.9.3

--- a/rules/configuration.smk
+++ b/rules/configuration.smk
@@ -41,8 +41,8 @@ rna_samples = pd.read_csv(config["rna_samples"], sep='\t', dtype='str', comment=
 atac_samples = pd.read_csv(config["atac_samples"], sep='\t', dtype='str', comment='#')
 # mimic s2s samples files
 # TODO: how to deal with unmerged replicates (technical/biological/merged in only 1 workflow)
-rna_samples = parse_samples(rna_samples, config)
-atac_samples = parse_samples(atac_samples, config)
+rna_samples = parse_samples(rna_samples, not config.get("merged_technical_reps", True), not config.get("merged_biological_reps", True), False, False)
+atac_samples = parse_samples(atac_samples, not config.get("merged_technical_reps", True), not config.get("merged_biological_reps", True), False, False)
 
 CONDITIONS = dict()
 CONTRASTS = dict()

--- a/rules/configuration.smk
+++ b/rules/configuration.smk
@@ -6,12 +6,7 @@ import pandas as pd
 import genomepy
 from snakemake.logging import logger
 from seq2science.util import parse_contrast
-try:
-    # s2s >=0.9
-    from seq2science.util import dense_samples as parse_samples
-except ImportError:
-    # s2s < 0.9
-    from seq2science.util import parse_samples
+from seq2science.util import dense_samples as parse_samples
 
 
 # NOTE: global variables are written in all caps

--- a/rules/deseq2.smk
+++ b/rules/deseq2.smk
@@ -22,9 +22,10 @@ rule deseq2:
         mkdir -p $outdir
         
         deseq2science \
-        -d {wildcards.contrast} \
-        -s {input.rna_samples} \
-        -c {input.genes} \
-        -o $outdir \
+        {wildcards.contrast} \
+        {input.rna_samples} \
+        {input.genes} \
+        $outdir \
+        --assembly {ASSEMBLY} \
         > {log} 2>&1
         """


### PR DESCRIPTION
Requires seq2science > 0.9.1. Specifically, [this PR](https://github.com/vanheeringen-lab/seq2science/pull/867).